### PR TITLE
Fix escaping with surrounds

### DIFF
--- a/smu.c
+++ b/smu.c
@@ -449,10 +449,12 @@ dosurround(const char *begin, const char *end, int newblock) {
 		start = begin + l;
 		p = start - 1;
 		do {
+			stop = p;
 			p = strstr(p + 1, surround[i].search);
 		} while(p && p[-1] == '\\');
-		if(!p || p >= end ||
-				!(stop = strstr(start, surround[i].search)) || stop >= end)
+		if (p && p[-1] != '\\')
+			stop = p;
+		if(!stop || stop < start || stop >= end)
 			continue;
 		fputs(surround[i].before, stdout);
 		if(surround[i].process)

--- a/testdoc
+++ b/testdoc
@@ -7,6 +7,8 @@ simple tests
 first paragraph.
 testing surround: _emph_ then **strong** and `code`.
 
+`\`escaped backticks\``.
+
 `x = *y * 6;`
 
 horizontal rule:


### PR DESCRIPTION
E.g.:

```
$ echo '*\*test*' | smu
```

Before:

```
<p>
<em>\</em>test*</p>
```

Now:

```
<p>
<em>*test</em></p>
```

I also added an example to testdoc motivating not enabling "process" for backticks, since I initially thought that might be the fix. Include or discard it as you please.
