### PR TITLE
Remove newline after <p>

### DIFF
--- a/smu.c
+++ b/smu.c
@@ -366,7 +366,7 @@ doparagraph(const char *begin, const char *end, int newblock) {
 		p = end;
 	if(p - begin <= 1)
 		return 0;
-	fputs("<p>\n", stdout);
+	fputs("<p>", stdout);
 	process(begin, p, 0);
 	fputs("</p>\n", stdout);
 	return -(p - begin);


### PR DESCRIPTION
Hi Gottox,
As we talked on IRC, <code><p>\n</code> adds a newline after we start <code><p></code> tag. For example:

```
<p>
I'm Foo</p>
```

I think the output could be improved if we delete the newline.

```
<p>I'm Foo</p>
```

Cheers :beers: 
