### PR TITLE
OOB read fixups

### DIFF
--- a/smu.c
+++ b/smu.c
@@ -528,7 +528,7 @@ dosurround(const char *begin, const char *end, int newblock) {
 		fputs(surround[i].before, stdout);
 
 		/* Single space at start and end are ignored */
-		if (stop - start > 2 && *start == ' ' && *(stop - 1) == ' ') {
+		if (stop - start > 1 && *start == ' ' && *(stop - 1) == ' ') {
 			start++;
 			stop--;
 			l++;

--- a/smu.c
+++ b/smu.c
@@ -232,7 +232,7 @@ dolineprefix(const char *begin, const char *end, int newblock) {
 		}
 
 		/* Skip empty lines in block */
-		while(*(buffer + j - 1) == '\n') {
+		while(buffer + j - 1 >= buffer && *(buffer + j - 1) == '\n') {
 			j--;
 		}
 
@@ -557,7 +557,7 @@ dounderline(const char *begin, const char *end, int newblock) {
 	if(l == 0)
 		return 0;
 	for(i = 0; i < LENGTH(underline); i++) {
-		for(j = 0; p + j != end && p[j] != '\n' && p[j] == underline[i].search[0]; j++);
+		for(j = 0; p + j < end && p[j] != '\n' && p[j] == underline[i].search[0]; j++);
 		if(j >= l) {
 			fputs(underline[i].before, stdout);
 			if(underline[i].process)
@@ -588,7 +588,7 @@ void
 hprint(const char *begin, const char *end) {
 	const char *p;
 
-	for(p = begin; p != end; p++) {
+	for(p = begin; p < end; p++) {
 		if(*p == '&')
 			fputs("&amp;", stdout);
 		else if(*p == '"')
@@ -624,10 +624,10 @@ process(const char *begin, const char *end, int newblock) {
 				fputc(*p, stdout);
 			p++;
 		}
-		for(q = p; q != end && *q == '\n'; q++);
+		for(q = p; q < end && *q == '\n'; q++);
 		if(q == end)
 			return;
-		else if(p[0] == '\n' && p + 1 != end && p[1] == '\n')
+		else if(p < end && p[0] == '\n' && p + 1 < end && p[1] == '\n')
 			newblock = 1;
 		else
 			newblock = affected < 0;

--- a/smu.c
+++ b/smu.c
@@ -171,14 +171,14 @@ dohtml(const char *begin, const char *end, int newblock) {
 		p += 2;
 		if(strncmp(p, tag, tagend - tag) == 0 && p[tagend - tag] == '>') {
 			p++;
-			fwrite(begin, sizeof(char), p - begin + tagend - tag + 1, stdout);
-			return p - begin + tagend - tag + 1;
+			fwrite(begin, sizeof(char), p - begin + tagend - tag - 1, stdout);
+			return p - begin + tagend - tag - 1;
 		}
 	}
 	p = strchr(tagend, '>');
 	if(p) {
-		fwrite(begin, sizeof(char), p - begin + 2, stdout);
-		return p - begin + 2;
+		fwrite(begin, sizeof(char), p - begin + 1, stdout);
+		return p - begin + 1;
 	}
 	else
 		return 0;
@@ -282,12 +282,12 @@ dolink(const char *begin, const char *end, int newblock) {
 			q++;
 	}
 
-	if((p = strpbrk(link, "\"'")) && p < end && q > p) {
+	if((p = strpbrk(link, "\"'")) && p < end && q - 1 > p + 1) {
 		sep = p[0]; /* separator: can be " or ' */
 		title = p + 1;
 		/* strip trailing whitespace */
 		for(linkend = p; linkend > link && isspace(*(linkend - 1)); linkend--);
-		for(titleend = q - 1; titleend > link && isspace(*(titleend)); titleend--);
+		for(titleend = q - 1; titleend > title && isspace(*(titleend)); titleend--);
 		if(*titleend != sep) {
 			return 0;
 		}
@@ -528,7 +528,7 @@ dosurround(const char *begin, const char *end, int newblock) {
 		fputs(surround[i].before, stdout);
 
 		/* Single space at start and end are ignored */
-		if (*start == ' ' && *(stop - 1) == ' ') {
+		if (stop - start > 2 && *start == ' ' && *(stop - 1) == ' ') {
 			start++;
 			stop--;
 			l++;
@@ -552,12 +552,12 @@ dounderline(const char *begin, const char *end, int newblock) {
 	if(!newblock)
 		return 0;
 	p = begin;
-	for(l = 0; p + l != end && p[l] != '\n'; l++);
+	for(l = 0; p + l + 1 != end && p[l] != '\n'; l++);
 	p += l + 1;
 	if(l == 0)
 		return 0;
 	for(i = 0; i < LENGTH(underline); i++) {
-		for(j = 0; p + j < end && p[j] != '\n' && p[j] == underline[i].search[0]; j++);
+		for(j = 0; p + j != end && p[j] != '\n' && p[j] == underline[i].search[0]; j++);
 		if(j >= l) {
 			fputs(underline[i].before, stdout);
 			if(underline[i].process)
@@ -588,7 +588,7 @@ void
 hprint(const char *begin, const char *end) {
 	const char *p;
 
-	for(p = begin; p < end; p++) {
+	for(p = begin; p != end; p++) {
 		if(*p == '&')
 			fputs("&amp;", stdout);
 		else if(*p == '"')
@@ -624,10 +624,10 @@ process(const char *begin, const char *end, int newblock) {
 				fputc(*p, stdout);
 			p++;
 		}
-		for(q = p; q < end && *q == '\n'; q++);
+		for(q = p; q != end && *q == '\n'; q++);
 		if(q == end)
 			return;
-		else if(p < end && p[0] == '\n' && p + 1 < end && p[1] == '\n')
+		else if(p[0] == '\n' && p + 1 != end && p[1] == '\n')
 			newblock = 1;
 		else
 			newblock = affected < 0;


### PR DESCRIPTION
This pull request fixes a few issues regarding Out-Of-Bounds reading. To note, the testing I've done to ensure full compatibility has not been extensive. I've tested against the provided `testdoc`, but some quirks that work through the use of these errors may break.


- 180-181
	+ The issue arises in certain cases when `p - begin + 2` is de-referenced from `begin`. In a case where the string ends at the ending delimiter (`'>'`), `p - begin + 2` would index at the character after the ending NULL byte. This causes an OOB read.
	+ The suggested fix will end at the ending NULL byte and not not the character right after. An issue of this implementation is that the NULL byte will also be included in the `fwrite` to `stdout`, which may or may not be intended behavior. 
- 235
	+ The `j` variable can have the value of 0 when arriving in the while loop. It then tries to de-reference a byte at `buffer + j - 1` with `buffer` being the base of a newly initialized buffer leading to a read at an invalid address
	+ The suggested fix allows to verify that the address to be de-referenced is in fact after `buffer`'s base
- 285
	+ `q` could be equal to `p + 1` in certain situations leading to a situation where `titleend` gets set to `p` and `title` to `p + 1`. This creates an issue in the later `hprint`s because the `start` is bigger than the `end` creating a situation where an OOB read is done.
	+ The suggested fix remediates this issue by verifying the maximum modifications of `q` and `p` work out. This also add a secondary check to make sure `titleend` is larger than `title` rather than `link` when decrementing `titleend`.
- 531
	+ In a situation where the string is a single space (`x`), `start` would be incremented to `x + 1` and `stop` would be decremented to `x` leading to an invalid `hprint` creating an OOB read.
	+ The suggested fix verifies the difference between `start` and `stop` is bigger than 1.
- 555
	+ In a situation where `p` is a string without a newline, `l` would be incremented to the length of `p`. The issue arises when `p` gets incremented by `l + 1` leading `p` to point towards invalid memory creating an OOB read.
	+ The suggested fix solves this issue by preemptively checking `p + l + 1` is not the `end`.