### PR TITLE
Suppress warning and add missing prototype

### DIFF
--- a/smu.c
+++ b/smu.c
@@ -32,6 +32,7 @@ static int doshortlink(const char *begin, const char *end, int newblock); /* Par
 static int dosurround(const char *begin, const char *end, int newblock);  /* Parser for surrounding tags */
 static int dounderline(const char *begin, const char *end, int newblock); /* Parser for underline tags */
 static void *ereallocz(void *p, size_t size);
+static void eprint(const char *format, ...);
 static void hprint(const char *begin, const char *end);                   /* escapes HTML and prints it to output */
 static void process(const char *begin, const char *end, int isblock);     /* Processes range between begin and end. */
 

--- a/smu.c
+++ b/smu.c
@@ -337,7 +337,7 @@ dolist(const char *begin, const char *end, int newblock) {
 	unsigned int i, j, indent, run, ul, isblock;
 	const char *p, *q;
 	char *buffer = NULL;
-	char marker;
+	char marker = 0;
 
 	isblock = 0;
 	if(newblock)


### PR DESCRIPTION
Hi,

This suppresses a warning (error due to -Werror) on GCC when compiling with -O3
```
smu.c:387:39: error: 'marker' may be used uninitialized in this function [-Werror=maybe-uninitialized]
  387 |                                 if(ul && *q == marker)
      |                                    ~~~^~~~~~~~~~~~~~~
```

Also adds missing prototype for `eprint()`