### PR TITLE
fix: bad ruler substitution

### DIFF
--- a/smu.c
+++ b/smu.c
@@ -207,7 +207,7 @@ dolineprefix(const char *begin, const char *end, int newblock) {
 		fputs(lineprefix[i].before, stdout);
 		if(lineprefix[i].search[l-1] == '\n') {
 			fputc('\n', stdout);
-			return l - 1;
+			return l - (p[l] == '\n');
 		}
 		if(!(buffer = malloc(BUFSIZ)))
 			eprint("Malloc failed.");


### PR DESCRIPTION
Closes: https://github.com/Gottox/smu/issues/22

---

Some before and after:

```console
$ printf "- - -\ntest\n- - -\n" | ./smu-1.5             
<hr />
test
<hr />
$ printf "- - -\ntest\n- - -\n" | ./smu-master 
<hr />

test
<hr />
-
$ printf "- - -\ntest\n- - -\n" | ./smu-fixed 
<hr />
test
<hr />
```

Note that certain cases, for example `- - -` without any blank lines before, are still kinda broken:

```console
$ printf "- - -\n\ntest\n- - -\n" | ./smu-1.5
<hr />

test
<hr />
$ printf "- - -\n\ntest\n- - -\n" | ./smu-master
<hr />
<p>test
<hr />
-</p>
$ printf "- - -\n\ntest\n- - -\n" | ./smu-fixed
<hr />
<p>test
<hr />
</p>
```

Reverting https://github.com/Gottox/smu/commit/7228740ed1e3b14d19744cde41655c21e2e84035 is probably a viable fix as well.
